### PR TITLE
feat(daemon): add MVP request loop + invalid JSON failure test

### DIFF
--- a/src/daemon/dap-daemon.ts
+++ b/src/daemon/dap-daemon.ts
@@ -5,6 +5,7 @@ import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { GodotFlowError } from '../errors.js';
 import type { DAPConfig } from '../types/engine.js';
+import { runRequestLoop } from './request-loop.js';
 
 type JsonRecord = Record<string, unknown>;
 
@@ -692,51 +693,26 @@ async function writeJsonLine(socket: Socket, payload: JsonRecord): Promise<void>
 }
 
 async function handleClientMessage(processState: DAPDaemonProcess, socket: Socket, rawLine: string): Promise<void> {
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(rawLine);
-  } catch (error) {
-    await writeJsonLine(socket, {
-      success: false,
-      error: {
-        code: 'INVALID_ARGS',
-        message: `Invalid JSON request: ${toErrorMessage(error)}`,
-      },
-    });
-    return;
-  }
+  let shouldShutdown = false;
+  const response = await runRequestLoop(rawLine, async (request) => {
+    const action = typeof request.action === 'string' ? request.action : 'execute';
 
-  if (!isRecord(parsed)) {
-    await writeJsonLine(socket, {
-      success: false,
-      error: { code: 'INVALID_ARGS', message: 'IPC request must be a JSON object' },
-    });
-    return;
-  }
-
-  const action = typeof parsed.action === 'string' ? parsed.action : 'execute';
-
-  try {
     if (action === 'status') {
       processState.status.connected = processState.dap.isConnected();
-      await writeJsonLine(socket, { success: true, data: processState.status });
-      return;
+      return { data: processState.status };
     }
 
     if (action === 'stop') {
-      await writeJsonLine(socket, { success: true, data: { stopping: true } });
-      setImmediate(() => {
-        void shutdownDaemon(processState);
-      });
-      return;
+      shouldShutdown = true;
+      return { data: { stopping: true } };
     }
 
     if (action !== 'execute') {
       throw new GodotFlowError('FUNCTION_NOT_FOUND', `Unknown daemon action: ${action}`);
     }
 
-    const fnName = typeof parsed.fnName === 'string' ? parsed.fnName : undefined;
-    const args = isRecord(parsed.args) ? parsed.args : {};
+    const fnName = typeof request.fnName === 'string' ? request.fnName : undefined;
+    const args = isRecord(request.args) ? request.args : {};
 
     if (!fnName) {
       throw new GodotFlowError('INVALID_ARGS', 'Missing fnName for execute action');
@@ -746,23 +722,17 @@ async function handleClientMessage(processState: DAPDaemonProcess, socket: Socke
     const data = await processState.dap.execute(fnName, args);
     processState.status.connected = processState.dap.isConnected();
 
-    await writeJsonLine(socket, {
-      success: true,
+    return {
       data,
       durationMs: Date.now() - startedAt,
-    });
-  } catch (error) {
-    const normalized = error instanceof GodotFlowError
-      ? error
-      : new GodotFlowError('EXECUTION_FAILED', toErrorMessage(error));
+    };
+  });
 
-    await writeJsonLine(socket, {
-      success: false,
-      error: {
-        code: normalized.code,
-        message: normalized.message,
-        details: normalized.details,
-      },
+  await writeJsonLine(socket, response as JsonRecord);
+
+  if (shouldShutdown) {
+    setImmediate(() => {
+      void shutdownDaemon(processState);
     });
   }
 }

--- a/src/daemon/request-loop.test.ts
+++ b/src/daemon/request-loop.test.ts
@@ -1,0 +1,15 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { runRequestLoop } from './request-loop.js';
+
+test('runRequestLoop returns INVALID_ARGS when request JSON is malformed', async () => {
+  const response = await runRequestLoop('{"action":', async () => ({ data: { ok: true } }));
+
+  assert.equal(response.success, false);
+  if (response.success) {
+    assert.fail('response should be failure');
+  }
+
+  assert.equal(response.error.code, 'INVALID_ARGS');
+  assert.match(response.error.message, /^Invalid JSON request:/);
+});

--- a/src/daemon/request-loop.ts
+++ b/src/daemon/request-loop.ts
@@ -1,0 +1,78 @@
+import { GodotFlowError } from '../errors.js';
+
+type JsonRecord = Record<string, unknown>;
+
+export interface RequestLoopError {
+  code: string;
+  message: string;
+  details?: unknown;
+}
+
+export type RequestLoopResponse =
+  | ({
+    success: true;
+  } & JsonRecord)
+  | {
+    success: false;
+    error: RequestLoopError;
+  };
+
+function isRecord(value: unknown): value is JsonRecord {
+  return typeof value === 'object' && value !== null;
+}
+
+function toErrorMessage(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message;
+  }
+  return String(error);
+}
+
+export async function runRequestLoop(
+  rawRequest: string,
+  process: (request: JsonRecord) => Promise<JsonRecord>,
+): Promise<RequestLoopResponse> {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(rawRequest);
+  } catch (error) {
+    return {
+      success: false,
+      error: {
+        code: 'INVALID_ARGS',
+        message: `Invalid JSON request: ${toErrorMessage(error)}`,
+      },
+    };
+  }
+
+  if (!isRecord(parsed)) {
+    return {
+      success: false,
+      error: {
+        code: 'INVALID_ARGS',
+        message: 'IPC request must be a JSON object',
+      },
+    };
+  }
+
+  try {
+    const payload = await process(parsed);
+    return {
+      success: true,
+      ...payload,
+    };
+  } catch (error) {
+    const normalized = error instanceof GodotFlowError
+      ? error
+      : new GodotFlowError('EXECUTION_FAILED', toErrorMessage(error));
+
+    return {
+      success: false,
+      error: {
+        code: normalized.code,
+        message: normalized.message,
+        details: normalized.details,
+      },
+    };
+  }
+}


### PR DESCRIPTION
## Summary
- add `runRequestLoop(rawRequest, process)` for request -> process -> response flow
- refactor `handleClientMessage` in `dap-daemon` to use the common request loop
- add malformed JSON failure-case test (`INVALID_ARGS`)

## Validation
- npm run build
- node --test dist/daemon/request-loop.test.js

## Risks / Follow-ups
- only malformed JSON failure path is covered right now; non-object / unsupported action cases should get follow-up tests
- this isolates the daemon request loop, but broader end-to-end daemon integration coverage is still needed
