### PR TITLE
fix: resolve naming, versioning, license, and test gaps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ on:
   pull_request:
 
 jobs:
-  build-and-typecheck:
+  build-typecheck-test:
     runs-on: ubuntu-latest
 
     steps:
@@ -31,3 +31,6 @@ jobs:
 
       - name: Typecheck
         run: npm run typecheck
+
+      - name: Test
+        run: npm test

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 HaD0Yun
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,16 +1,19 @@
-# godot-flow
+# GoPeak CLI
 
 [![](https://badge.mcpx.dev?type=server 'MCP Server')](https://modelcontextprotocol.io/introduction)
 [![Made with Godot](https://img.shields.io/badge/Made%20with-Godot-478CBF?style=flat&logo=godot%20engine&logoColor=white)](https://godotengine.org)
 [![](https://img.shields.io/badge/Node.js-339933?style=flat&logo=nodedotjs&logoColor=white 'Node.js')](https://nodejs.org/en/download/)
 [![](https://img.shields.io/badge/TypeScript-3178C6?style=flat&logo=typescript&logoColor=white 'TypeScript')](https://www.typescriptlang.org/)
-[![](https://img.shields.io/github/last-commit/HaD0Yun/godot-flow 'Last Commit')](https://github.com/HaD0Yun/godot-flow/commits/main)
-[![](https://img.shields.io/github/stars/HaD0Yun/godot-flow 'Stars')](https://github.com/HaD0Yun/godot-flow/stargazers)
+[![](https://img.shields.io/github/last-commit/HaD0Yun/Gopeak-godot-Cli 'Last Commit')](https://github.com/HaD0Yun/Gopeak-godot-Cli/commits/main)
+[![](https://img.shields.io/github/stars/HaD0Yun/Gopeak-godot-Cli 'Stars')](https://github.com/HaD0Yun/Gopeak-godot-Cli/stargazers)
+[![](https://img.shields.io/badge/npm-gopeak--cli-CB3837?style=flat&logo=npm&logoColor=white 'npm package')](https://www.npmjs.com/package/gopeak-cli)
 [![](https://img.shields.io/badge/License-MIT-red.svg 'MIT License')](https://opensource.org/licenses/MIT)
 
 **220 Godot functions through 4 MCP meta-tools. 342 tokens instead of 18,606.** ([measured](benchmark/evidence/benchmark-report.json))
 
-`godot-flow` is a 3-layer architecture that lets AI assistants discover and execute Godot engine capabilities without loading massive tool schemas into context. Born from [GoPeak (godot-mcp)](https://github.com/HaD0Yun/godot-mcp), it compresses 220 individually-registered MCP tools into 4 meta-tools — a **54× token reduction** (measured via actual JSON-RPC `tools/list` responses). Adding functions costs zero extra tokens.
+`gopeak-cli` is the published npm package and terminal command for this repository (`HaD0Yun/Gopeak-godot-Cli`). It ships the `godot-flow` MCP architecture: a 3-layer design that lets AI assistants discover and execute Godot engine capabilities without loading massive tool schemas into context. Born from [GoPeak (godot-mcp)](https://github.com/HaD0Yun/godot-mcp), the `godot-flow` layer compresses 220 individually-registered MCP tools into 4 meta-tools — a **54× token reduction** (measured via actual JSON-RPC `tools/list` responses). Adding functions costs zero extra tokens.
+
+> **Naming note**: repo = `Gopeak-godot-Cli`, package/CLI = `gopeak-cli`, MCP server/architecture = `godot-flow`.
 
 > **Successor to GoPeak**: 220 functions (110 more than GoPeak's 110), same Godot integration depth, radically smaller context footprint.
 
@@ -104,21 +107,21 @@ The AI discovers functions on-demand via `listfunc`/`findfunc`/`viewfunc`, then 
 ### Quick Start (recommended)
 
 ```bash
-npx godot-flow listfunc
+npx gopeak-cli listfunc
 ```
 
 ### Global Install
 
 ```bash
-npm install -g godot-flow
-godot-flow listfunc
+npm install -g gopeak-cli
+gopeak-cli listfunc
 ```
 
 ### From Source
 
 ```bash
-git clone https://github.com/HaD0Yun/godot-flow.git
-cd godot-flow
+git clone https://github.com/HaD0Yun/Gopeak-godot-Cli.git
+cd Gopeak-godot-Cli
 npm install
 npm run build
 ```
@@ -132,8 +135,8 @@ npm run build
 ```json
 {
   "mcpServers": {
-    "godot-flow": {
-      "command": "godot-flow",
+    "gopeak-cli": {
+      "command": "gopeak-cli",
       "args": [],
       "env": {
         "GODOT_FLOW_PROJECT_PATH": "/path/to/your/godot/project",
@@ -150,8 +153,8 @@ npm run build
 {
   "mcp": {
     "servers": {
-      "godot-flow": {
-        "command": "godot-flow",
+      "gopeak-cli": {
+        "command": "gopeak-cli",
         "args": [],
         "env": {
           "GODOT_FLOW_PROJECT_PATH": "/path/to/your/godot/project"
@@ -167,9 +170,9 @@ npm run build
 ```json
 {
   "mcpServers": {
-    "godot-flow": {
+    "gopeak-cli": {
       "command": "npx",
-      "args": ["-y", "godot-flow"],
+      "args": ["-y", "gopeak-cli"],
       "env": {
         "GODOT_FLOW_PROJECT_PATH": "/path/to/your/godot/project"
       }
@@ -181,6 +184,8 @@ npm run build
 ---
 
 ## 4 MCP Meta-Tools
+
+The executable you run is `gopeak-cli`, while the MCP server metadata exposed to clients remains `godot-flow`.
 
 These are the **only 4 tools** exposed to your AI assistant:
 
@@ -230,27 +235,27 @@ The CLI mirrors the MCP tools for terminal use and debugging:
 
 ```bash
 # List all functions
-godot-flow listfunc
+gopeak-cli listfunc
 
 # List functions in a category
-godot-flow listfunc --category scene
+gopeak-cli listfunc --category scene
 
 # Search for functions
-godot-flow findfunc "breakpoint"
-godot-flow findfunc "script" --category resource
+gopeak-cli findfunc "breakpoint"
+gopeak-cli findfunc "script" --category resource
 
 # View function details (including input schema)
-godot-flow viewfunc create_scene
+gopeak-cli viewfunc create_scene
 
 # Execute a function
-godot-flow exec create_scene --args '{"scene_name": "Player", "root_type": "CharacterBody2D"}'
-godot-flow exec run_project
-godot-flow exec lsp_diagnostics --args '{"script_path": "res://scripts/player.gd"}'
+gopeak-cli exec create_scene --args '{"scene_name": "Player", "root_type": "CharacterBody2D"}'
+gopeak-cli exec run_project
+gopeak-cli exec lsp_diagnostics --args '{"script_path": "res://scripts/player.gd"}'
 
 # Install AI platform skill files
-godot-flow install-skill --platform opencode
-godot-flow install-skill --platform claude
-godot-flow install-skill --platform codex
+gopeak-cli install-skill --platform opencode
+gopeak-cli install-skill --platform claude
+gopeak-cli install-skill --platform codex
 ```
 
 ---
@@ -270,13 +275,13 @@ godot-flow install-skill --platform codex
 
 ## AI Platform Skills
 
-godot-flow includes lightweight SKILL.md files (< 100 lines each) that teach AI assistants the optimal workflow patterns without embedding full schemas:
+gopeak-cli includes lightweight SKILL.md files (< 100 lines each) that teach AI assistants the optimal workflow patterns without embedding full schemas:
 
 | Platform | Install Command | Lines |
 |----------|----------------|-------|
-| OpenCode | `godot-flow install-skill --platform opencode` | 34 |
-| Claude | `godot-flow install-skill --platform claude` | 54 |
-| Codex | `godot-flow install-skill --platform codex` | 54 |
+| OpenCode | `gopeak-cli install-skill --platform opencode` | 34 |
+| Claude | `gopeak-cli install-skill --platform claude` | 54 |
+| Codex | `gopeak-cli install-skill --platform codex` | 54 |
 
 Skills teach the AI the **discover → inspect → execute** pattern:
 1. `findfunc` or `listfunc` to discover what's available
@@ -798,19 +803,19 @@ CLI가 4개 서브커맨드를 모두 올바르게 실행하는지 확인합니�
 
 ```bash
 # 전체 함수 목록 출력 — 110개가 나와야 함
-godot-flow listfunc
+gopeak-cli listfunc
 
 # 카테고리 필터링 — dap 카테고리에 10개 함수
-godot-flow listfunc --category dap
+gopeak-cli listfunc --category dap
 
 # 패턴 검색 — "break"로 검색하면 dap_set_breakpoint, dap_remove_breakpoint 포함
-godot-flow findfunc break
+gopeak-cli findfunc break
 
 # 함수 상세 조회 — inputSchema가 출력되어야 함
-godot-flow viewfunc create_scene
+gopeak-cli viewfunc create_scene
 
 # 실행 (Godot 프로젝트 경로 필요)
-GODOT_FLOW_PROJECT_PATH=/path/to/project godot-flow exec get_project_info
+GODOT_FLOW_PROJECT_PATH=/path/to/project gopeak-cli exec get_project_info
 ```
 
 ### 직접 실행해 볼 수 있는 시나리오
@@ -820,13 +825,13 @@ Godot 프로젝트가 있다면, 아래 시나리오를 순서대로 실행해�
 **시나리오 1: 함수 탐색 → 조회 → 실행 (Headless)**
 ```bash
 # 1. scene 관련 함수 찾기
-godot-flow findfunc scene --category scene
+gopeak-cli findfunc scene --category scene
 
 # 2. create_scene의 인자 확인
-godot-flow viewfunc create_scene
+gopeak-cli viewfunc create_scene
 
 # 3. 씬 생성 실행
-godot-flow exec create_scene --args '{"scene_name": "TestEnemy", "root_type": "CharacterBody2D"}'
+gopeak-cli exec create_scene --args '{"scene_name": "TestEnemy", "root_type": "CharacterBody2D"}'
 
 # 4. 결과 확인: res://scenes/TestEnemy.tscn 파일이 생성됨
 ```
@@ -834,7 +839,7 @@ godot-flow exec create_scene --args '{"scene_name": "TestEnemy", "root_type": "C
 **시나리오 2: LSP 진단 (에디터 실행 필요)**
 ```bash
 # Godot 에디터가 열려 있어야 LSP 포트 6005가 활성화됨
-godot-flow exec lsp_diagnostics --args '{"script_path": "res://scripts/player.gd"}'
+gopeak-cli exec lsp_diagnostics --args '{"script_path": "res://scripts/player.gd"}'
 
 # 에러/경고 목록이 JSON으로 반환됨
 ```
@@ -842,31 +847,31 @@ godot-flow exec lsp_diagnostics --args '{"script_path": "res://scripts/player.gd
 **시나리오 3: 런타임 인스펙션 (게임 실행 필요)**
 ```bash
 # 1. 프로젝트 실행
-godot-flow exec run_project
+gopeak-cli exec run_project
 
 # 2. 라이브 씬 트리 조회
-godot-flow exec inspect_runtime_tree
+gopeak-cli exec inspect_runtime_tree
 
 # 3. 스크린샷 캡처
-godot-flow exec capture_screenshot
+gopeak-cli exec capture_screenshot
 
 # 4. 프로젝트 종료
-godot-flow exec stop_project
+gopeak-cli exec stop_project
 ```
 
 **시나리오 4: DAP 디버깅 (게임 실행 필요)**
 ```bash
 # 1. 브레이크포인트 설정
-godot-flow exec dap_set_breakpoint --args '{"path": "res://scripts/player.gd", "line": 42}'
+gopeak-cli exec dap_set_breakpoint --args '{"path": "res://scripts/player.gd", "line": 42}'
 
 # 2. 브레이크포인트에서 멈추면 스택 트레이스 확인
-godot-flow exec dap_get_stack_trace
+gopeak-cli exec dap_get_stack_trace
 
 # 3. 변수 평가
-godot-flow exec dap_evaluate --args '{"expression": "player.position"}'
+gopeak-cli exec dap_evaluate --args '{"expression": "player.position"}'
 
 # 4. 실행 계속
-godot-flow exec dap_continue
+gopeak-cli exec dap_continue
 ```
 
 ### 코드 품질 기준

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gopeak-cli",
   "version": "1.0.0",
-  "description": "CLI-first Godot automation with optional MCP integration via 4 meta-tools",
+  "description": "GoPeak CLI for Godot automation, shipping the godot-flow MCP architecture via 4 meta-tools",
   "type": "module",
   "main": "dist/mcp/index.js",
   "bin": {
@@ -20,7 +20,7 @@
     "prepare": "npm run build",
     "postinstall": "node -e \"try{require('child_process').execFileSync(process.execPath,['dist/cli.js','setup','--silent'],{stdio:'ignore'})}catch{}\"",
     "prepack": "npm run build",
-    "test": "node dist/daemon/request-loop.test.js"
+    "test": "node --test $(find dist -name '*.test.js' -print)"
   },
   "keywords": [
     "godot",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -18,6 +18,7 @@ import { setupShellHooks } from './cli/setup.js';
 import { starGodotFlow } from './cli/star.js';
 import { uninstallHooks } from './cli/uninstall.js';
 import { getLocalVersion } from './cli/utils.js';
+import { APP_VERSION } from './version.js';
 import { CONFIG_ENV_KEYS, loadConfig } from './config.js';
 import { GodotFlowError } from './errors.js';
 import type { ExecutionResult } from './types/engine.js';
@@ -444,7 +445,7 @@ const program = new Command();
 
 program
   .name('gopeak-cli')
-  .version('1.0.0')
+  .version(APP_VERSION)
   .description('CLI-first Godot automation for humans and AI agents')
   .option('--format <type>', 'Output format (json|text)', 'json')
   .option('--timeout <ms>', 'Timeout in ms')

--- a/src/cli/utils.ts
+++ b/src/cli/utils.ts
@@ -2,9 +2,9 @@ import { exec } from 'node:child_process';
 import { existsSync, mkdirSync, readFileSync, unlinkSync, writeFileSync } from 'node:fs';
 import { get as httpsGet } from 'node:https';
 import { homedir } from 'node:os';
-import { dirname, join } from 'node:path';
+import { join } from 'node:path';
 import { promisify } from 'node:util';
-import { fileURLToPath } from 'node:url';
+import { APP_VERSION } from '../version.js';
 
 const execAsync = promisify(exec);
 
@@ -50,15 +50,7 @@ export function ensureFlowDir(): void {
 }
 
 export function getLocalVersion(): string {
-  try {
-    const __filename = fileURLToPath(import.meta.url);
-    const __dirname = dirname(__filename);
-    const packagePath = join(__dirname, '..', '..', 'package.json');
-    const packageJson = JSON.parse(readFileSync(packagePath, 'utf8')) as { version?: string };
-    return typeof packageJson.version === 'string' ? packageJson.version : '0.0.0';
-  } catch {
-    return '0.0.0';
-  }
+  return APP_VERSION;
 }
 
 function fetchJson(url: string): Promise<Record<string, unknown> | null> {

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -1,0 +1,73 @@
+import assert from 'node:assert/strict';
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import test from 'node:test';
+import { loadConfig } from './config.js';
+
+const ORIGINAL_ENV = { ...process.env };
+const ORIGINAL_CWD = process.cwd();
+
+function resetProcessState(): void {
+  process.chdir(ORIGINAL_CWD);
+
+  for (const key of Object.keys(process.env)) {
+    if (!(key in ORIGINAL_ENV)) {
+      delete process.env[key];
+    }
+  }
+
+  Object.assign(process.env, ORIGINAL_ENV);
+}
+
+test.afterEach(() => {
+  resetProcessState();
+});
+
+test('loadConfig applies CLI overrides before env and defaults', () => {
+  process.env.GODOT_FLOW_PROJECT_PATH = '/env/project';
+  process.env.GODOT_FLOW_GODOT_PATH = '/usr/bin/godot-env';
+  process.env.GODOT_FLOW_RUNTIME_PORT = '8888';
+  process.env.GODOT_FLOW_LSP_PORT = '7000';
+  process.env.GODOT_FLOW_DAP_PORT = '7001';
+  process.env.GODOT_FLOW_TIMEOUT = '45000';
+
+  const config = loadConfig({
+    projectPath: '/cli/project',
+    godotPath: '/usr/bin/godot-cli',
+    runtimePort: 9000,
+    timeoutMs: 12345,
+  });
+
+  assert.deepEqual(config, {
+    projectPath: '/cli/project',
+    godotPath: '/usr/bin/godot-cli',
+    runtimePort: 9000,
+    lspPort: 7000,
+    dapPort: 7001,
+    timeoutMs: 12345,
+  });
+});
+
+test('loadConfig infers projectPath from cwd when project.godot exists', () => {
+  const projectDir = mkdtempSync(join(tmpdir(), 'gopeak-config-'));
+  writeFileSync(join(projectDir, 'project.godot'), '[application]\nconfig/name="Test"\n');
+  process.chdir(projectDir);
+
+  delete process.env.GODOT_FLOW_PROJECT_PATH;
+
+  const config = loadConfig();
+  assert.equal(config.projectPath, projectDir);
+  assert.equal(config.godotPath, 'godot');
+  assert.equal(config.runtimePort, 7777);
+  assert.equal(config.timeoutMs, 30000);
+});
+
+test('loadConfig rejects invalid port and timeout environment values', () => {
+  process.env.GODOT_FLOW_RUNTIME_PORT = '0';
+  assert.throws(() => loadConfig(), /Invalid GODOT_FLOW_RUNTIME_PORT: expected port 1-65535, got 0/);
+
+  resetProcessState();
+  process.env.GODOT_FLOW_TIMEOUT = '-1';
+  assert.throws(() => loadConfig(), /Invalid GODOT_FLOW_TIMEOUT: expected positive integer, got -1/);
+});

--- a/src/daemon/request-loop.test.ts
+++ b/src/daemon/request-loop.test.ts
@@ -1,5 +1,6 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
+import { GodotFlowError } from '../errors.js';
 import { runRequestLoop } from './request-loop.js';
 
 test('runRequestLoop returns INVALID_ARGS when request JSON is malformed', async () => {
@@ -12,4 +13,67 @@ test('runRequestLoop returns INVALID_ARGS when request JSON is malformed', async
 
   assert.equal(response.error.code, 'INVALID_ARGS');
   assert.match(response.error.message, /^Invalid JSON request:/);
+});
+
+test('runRequestLoop rejects non-object JSON payloads', async () => {
+  const response = await runRequestLoop('[1,2,3]', async () => ({ ok: true }));
+
+  assert.equal(response.success, false);
+  if (response.success) {
+    assert.fail('response should be failure');
+  }
+
+  assert.deepEqual(response.error, {
+    code: 'INVALID_ARGS',
+    message: 'IPC request must be a JSON object',
+  });
+});
+
+test('runRequestLoop returns success payloads with success flag', async () => {
+  const response = await runRequestLoop('{"action":"ping"}', async (request) => ({
+    echoedAction: request.action,
+    nested: { ok: true },
+  }));
+
+  assert.equal(response.success, true);
+  if (!response.success) {
+    assert.fail('response should be success');
+  }
+
+  assert.equal(response.echoedAction, 'ping');
+  assert.deepEqual(response.nested, { ok: true });
+});
+
+test('runRequestLoop preserves GodotFlowError code and details', async () => {
+  const response = await runRequestLoop('{"action":"fail"}', async () => {
+    throw new GodotFlowError('ENGINE_TIMEOUT', 'Timed out', { timeoutMs: 1234 });
+  });
+
+  assert.equal(response.success, false);
+  if (response.success) {
+    assert.fail('response should be failure');
+  }
+
+  assert.deepEqual(response.error, {
+    code: 'ENGINE_TIMEOUT',
+    message: 'Timed out',
+    details: { timeoutMs: 1234 },
+  });
+});
+
+test('runRequestLoop normalizes unknown errors to EXECUTION_FAILED', async () => {
+  const response = await runRequestLoop('{"action":"explode"}', async () => {
+    throw 'boom';
+  });
+
+  assert.equal(response.success, false);
+  if (response.success) {
+    assert.fail('response should be failure');
+  }
+
+  assert.deepEqual(response.error, {
+    code: 'EXECUTION_FAILED',
+    message: 'boom',
+    details: undefined,
+  });
 });

--- a/src/daemon/request-loop.ts
+++ b/src/daemon/request-loop.ts
@@ -18,7 +18,7 @@ export type RequestLoopResponse =
   };
 
 function isRecord(value: unknown): value is JsonRecord {
-  return typeof value === 'object' && value !== null;
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
 
 function toErrorMessage(error: unknown): string {

--- a/src/mcp/server.test.ts
+++ b/src/mcp/server.test.ts
@@ -1,0 +1,59 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { ZodError, z } from 'zod';
+import { GodotFlowError } from '../errors.js';
+import { toToolError, toolResult } from './server.js';
+
+test('toolResult keeps object payloads structured and wraps primitives', () => {
+  const objectResult = toolResult({ ok: true, nested: { count: 1 } });
+  assert.deepEqual(objectResult.structuredContent, { ok: true, nested: { count: 1 } });
+  assert.equal(objectResult.content[0]?.type, 'text');
+  assert.match(objectResult.content[0]?.text ?? '', /"ok": true/);
+
+  const primitiveResult = toolResult(42);
+  assert.deepEqual(primitiveResult.structuredContent, { data: 42 });
+});
+
+test('toToolError preserves GodotFlowError MCP payloads', () => {
+  const error = toToolError(new GodotFlowError('FUNCTION_NOT_FOUND', 'Missing function', { name: 'x' }));
+
+  assert.equal(error.isError, true);
+  assert.deepEqual(JSON.parse(error.content[0]?.text ?? '{}'), {
+    error: {
+      code: 'FUNCTION_NOT_FOUND',
+      message: 'Missing function',
+      details: { name: 'x' },
+    },
+  });
+});
+
+test('toToolError normalizes Zod validation errors to INVALID_ARGS', () => {
+  const schema = z.object({ count: z.number() });
+  let zodError: ZodError | undefined;
+
+  try {
+    schema.parse({ count: 'nope' });
+  } catch (error) {
+    zodError = error as ZodError;
+  }
+
+  assert.ok(zodError);
+  const normalized = toToolError(zodError);
+  const payload = JSON.parse(normalized.content[0]?.text ?? '{}');
+
+  assert.equal(payload.error.code, 'INVALID_ARGS');
+  assert.equal(payload.error.message, 'Invalid function arguments');
+  assert.equal(Array.isArray(payload.error.details?.issues), true);
+});
+
+test('toToolError normalizes unknown failures to EXECUTION_FAILED', () => {
+  const normalized = toToolError(new Error('kaboom'));
+  const payload = JSON.parse(normalized.content[0]?.text ?? '{}');
+
+  assert.deepEqual(payload, {
+    error: {
+      code: 'EXECUTION_FAILED',
+      message: 'kaboom',
+    },
+  });
+});

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -8,9 +8,10 @@ import { executeDAP } from '../engine/dap.js';
 import { GodotFlowError } from '../errors.js';
 import { jsonSchemaToZod } from '../schema-utils.js';
 import { loadConfig } from '../config.js';
+import { APP_VERSION } from '../version.js';
 import type { DAPConfig, HeadlessConfig, LSPConfig, RuntimeConfig } from '../types/engine.js';
 
-const toolResult = (value: unknown): {
+export const toolResult = (value: unknown): {
   content: Array<{ type: 'text'; text: string }>;
   structuredContent: Record<string, unknown>;
 } => {
@@ -24,7 +25,7 @@ const toolResult = (value: unknown): {
   };
 };
 
-function toToolError(error: unknown): { content: Array<{ type: 'text'; text: string }>; isError: true } {
+export function toToolError(error: unknown): { content: Array<{ type: 'text'; text: string }>; isError: true } {
   if (error instanceof GodotFlowError) {
     return error.toMcpError();
   }
@@ -109,7 +110,7 @@ export function createServer(): McpServer {
 
   const server = new McpServer({
     name: 'godot-flow',
-    version: '0.1.0',
+    version: APP_VERSION,
   });
 
   server.tool(

--- a/src/schema-utils.test.ts
+++ b/src/schema-utils.test.ts
@@ -1,0 +1,50 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { jsonSchemaToZod } from './schema-utils.js';
+
+test('jsonSchemaToZod builds object schemas with required and optional fields', () => {
+  const schema = jsonSchemaToZod({
+    type: 'object',
+    properties: {
+      name: { type: 'string' },
+      retries: { type: 'integer' },
+      enabled: { type: 'boolean' },
+    },
+    required: ['name', 'enabled'],
+  });
+
+  const parsed = schema.parse({ name: 'agent', enabled: true });
+  assert.deepEqual(parsed, { name: 'agent', enabled: true });
+
+  const withOptional = schema.parse({ name: 'agent', enabled: false, retries: 3 });
+  assert.deepEqual(withOptional, { name: 'agent', enabled: false, retries: 3 });
+
+  assert.throws(() => schema.parse({ enabled: true }), /Required/);
+  assert.throws(() => schema.parse({ name: 'agent', enabled: true, retries: 2.5 }), /integer/);
+});
+
+test('jsonSchemaToZod supports string enums and mixed literal unions', () => {
+  const stringEnum = jsonSchemaToZod({ enum: ['headless', 'runtime'] });
+  assert.equal(stringEnum.parse('runtime'), 'runtime');
+  assert.throws(() => stringEnum.parse('dap'), /Invalid enum value/);
+
+  const mixedEnum = jsonSchemaToZod({ enum: ['ok', 2, false, null] });
+  assert.equal(mixedEnum.parse(2), 2);
+  assert.equal(mixedEnum.parse(false), false);
+  assert.equal(mixedEnum.parse(null), null);
+  assert.throws(() => mixedEnum.parse(true), /Invalid input/);
+});
+
+test('jsonSchemaToZod handles array items and unknown fallbacks', () => {
+  const arraySchema = jsonSchemaToZod({
+    type: 'array',
+    items: { type: 'number' },
+  });
+
+  assert.deepEqual(arraySchema.parse([1, 2, 3]), [1, 2, 3]);
+  assert.throws(() => arraySchema.parse([1, '2']), /number/);
+
+  const unknownSchema = jsonSchemaToZod({});
+  const sample = { arbitrary: ['value'] };
+  assert.equal(unknownSchema.parse(sample), sample);
+});

--- a/src/version.test.ts
+++ b/src/version.test.ts
@@ -1,0 +1,27 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+import { createServer } from './mcp/server.js';
+import { APP_VERSION } from './version.js';
+
+function readPackageVersion(): string {
+  const __filename = fileURLToPath(import.meta.url);
+  const __dirname = dirname(__filename);
+  const packagePath = join(__dirname, '..', 'package.json');
+  const packageJson = JSON.parse(readFileSync(packagePath, 'utf8')) as { version?: string };
+  return packageJson.version ?? '0.0.0';
+}
+
+test('APP_VERSION stays aligned with package.json version', () => {
+  assert.equal(APP_VERSION, readPackageVersion());
+});
+
+test('createServer exposes package version in MCP server metadata', () => {
+  const server = createServer();
+  const serverInfo = Reflect.get(server.server as object, '_serverInfo') as { version: string; name: string };
+
+  assert.equal(serverInfo.name, 'godot-flow');
+  assert.equal(serverInfo.version, APP_VERSION);
+});

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,0 +1,21 @@
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+interface PackageMetadata {
+  version?: string;
+}
+
+function readPackageVersion(): string {
+  try {
+    const __filename = fileURLToPath(import.meta.url);
+    const __dirname = dirname(__filename);
+    const packagePath = join(__dirname, '..', 'package.json');
+    const packageJson = JSON.parse(readFileSync(packagePath, 'utf8')) as PackageMetadata;
+    return typeof packageJson.version === 'string' ? packageJson.version : '0.0.0';
+  } catch {
+    return '0.0.0';
+  }
+}
+
+export const APP_VERSION = readPackageVersion();


### PR DESCRIPTION
## Summary
- align repo/package/README naming around GoPeak CLI while clarifying `godot-flow` as the MCP architecture/server identity
- use a single package-derived app version across CLI + MCP server and add regression tests
- add the missing MIT `LICENSE`, run tests in CI, and expand pure-logic unit coverage
- fix the request-loop object guard revealed by the new tests

## Verification
- `npm run build`
- `npm run typecheck`
- `npm test`

## Closes
- Closes #9
- Closes #10
- Closes #11
- Closes #12
- Closes #13