### PR TITLE
fix: stop postinstall from editing shell rc files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1025,7 +1025,7 @@ MIT — see [LICENSE](LICENSE).
 
 ## Shell helper commands
 
-`gopeak-cli` can now install shell hooks that detect supported AI CLI commands already present on your machine and wrap them with cached update + GitHub star prompts.
+`gopeak-cli` can optionally install shell hooks that detect supported AI CLI commands already present on your machine and wrap them with cached update + GitHub star prompts. `npm install` does **not** modify your shell rc files automatically; shell integration is explicit opt-in via `gopeak-cli setup`.
 
 Supported command detection at setup time: `claude`, `claudecode`, `codex`, `gemini`, `copilot`, `opencode`, `omx`.
 

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "watch": "tsc --watch",
     "typecheck": "tsc --noEmit",
     "prepare": "npm run build",
-    "postinstall": "node -e \"try{require('child_process').execFileSync(process.execPath,['dist/cli.js','setup','--silent'],{stdio:'ignore'})}catch{}\"",
+    "postinstall": "node -e \"console.log('[gopeak-cli] Optional shell hooks are not installed automatically. Run \\\"gopeak-cli setup\\\" to enable them.')\"",
     "prepack": "npm run build",
     "test": "node dist/daemon/request-loop.test.js"
   },


### PR DESCRIPTION
## Summary
- replace the install-time shell hook setup with an informational postinstall message
- document that shell integration is explicit opt-in via `gopeak-cli setup`
- keep the change focused to issue #15 only

## Validation
- npm install
- npm run build
- npm test
- temp-HOME postinstall check confirmed `.bashrc` and `.zshrc` stay unchanged

Closes #15