### PR TITLE
Add lightweight CLI smoke coverage in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,3 +31,6 @@ jobs:
 
       - name: Typecheck
         run: npm run typecheck
+
+      - name: CLI smoke tests
+        run: npm run test:compiled

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 
 **220 Godot functions through 4 MCP meta-tools. 342 tokens instead of 18,606.** ([measured](benchmark/evidence/benchmark-report.json))
 
+
 `godot-flow` is a 3-layer architecture that lets AI assistants discover and execute Godot engine capabilities without loading massive tool schemas into context. Born from [GoPeak (godot-mcp)](https://github.com/HaD0Yun/godot-mcp), it compresses 220 individually-registered MCP tools into 4 meta-tools — a **54× token reduction** (measured via actual JSON-RPC `tools/list` responses). Adding functions costs zero extra tokens.
 
 > **Successor to GoPeak**: 220 functions (110 more than GoPeak's 110), same Godot integration depth, radically smaller context footprint.
@@ -740,7 +741,9 @@ The DAP engine uses a background daemon for persistent debug sessions:
 
 ## Testing & Verification
 
-godot-flow에는 별도 테스트 프레임워크(jest, vitest 등)가 없습니다. 대신 **구조적 검증**과 **실행 기반 검증** 두 축으로 품질을 보장합니다.
+godot-flow에는 대형 테스트 프레임워크(jest, vitest 등)를 도입하지 않았습니다. 대신 Node 내장 테스트 러너, TypeScript strict 검증, 레지스트리 검증, 그리고 **가벼운 CLI smoke test**를 조합해 품질을 확인합니다.
+
+현재 CI는 실제 빌드 결과물(`dist/cli.js`)을 대상으로 최소한의 엔트리포인트 smoke 검증을 수행합니다. 예를 들어 `--help`, `--version`, 그리고 **실제 Godot 바이너리 대신 가짜 실행 파일을 사용한 안전한 headless 라우팅 1건**을 확인합니다. 즉, 설치/라우팅 회귀는 자동으로 잡지만, **실제 Godot 프로젝트와 함께하는 완전한 end-to-end 보증은 아직 별도 수동/통합 검증 범위**입니다.
 
 ### 빌드 & 타입 검증
 

--- a/package.json
+++ b/package.json
@@ -20,7 +20,9 @@
     "prepare": "npm run build",
     "postinstall": "node -e \"try{require('child_process').execFileSync(process.execPath,['dist/cli.js','setup','--silent'],{stdio:'ignore'})}catch{}\"",
     "prepack": "npm run build",
-    "test": "node dist/daemon/request-loop.test.js"
+    "test": "npm run build && npm run test:compiled",
+    "test:compiled": "node --test dist/daemon/request-loop.test.js dist/cli.smoke.test.js",
+    "test:smoke": "npm run build && node --test dist/cli.smoke.test.js"
   },
   "keywords": [
     "godot",

--- a/src/cli.smoke.test.ts
+++ b/src/cli.smoke.test.ts
@@ -1,0 +1,78 @@
+import assert from 'node:assert/strict';
+import { mkdtempSync, writeFileSync, chmodSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { spawnSync } from 'node:child_process';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const distCliPath = resolve(__dirname, './cli.js');
+
+function runCli(args: string[], env: NodeJS.ProcessEnv = process.env) {
+  return spawnSync(process.execPath, [distCliPath, ...args], {
+    env,
+    encoding: 'utf8',
+  });
+}
+
+test('dist CLI --help prints usage information', () => {
+  const result = runCli(['--help']);
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /Usage: gopeak-cli/i);
+  assert.match(result.stdout, /listfunc/);
+  assert.equal(result.stderr, '');
+});
+
+test('dist CLI --version prints the packaged version', () => {
+  const result = runCli(['--version']);
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(result.stdout.trim(), '1.0.0');
+  assert.equal(result.stderr, '');
+});
+
+test('dist CLI listfunc routes through the registry without Godot', () => {
+  const result = runCli(['listfunc', '--category', 'scene', '--format', 'json']);
+
+  assert.equal(result.status, 0, result.stderr);
+  const payload = JSON.parse(result.stdout) as Array<Record<string, unknown>>;
+  assert.ok(payload.length > 0);
+  assert.ok(payload.every((entry) => entry.category === 'scene'));
+  assert.ok(payload.some((entry) => typeof entry.name === 'string'));
+});
+
+test('dist CLI exec get_project_info routes to headless with a fake Godot binary', () => {
+  const tempRoot = mkdtempSync(join(tmpdir(), 'gopeak-cli-smoke-'));
+
+  try {
+    const fakeGodotPath = join(tempRoot, 'fake-godot.mjs');
+    writeFileSync(join(tempRoot, 'project.godot'), '');
+    writeFileSync(
+      fakeGodotPath,
+      `#!/usr/bin/env node\nconst argv = process.argv.slice(2);\nconst fnName = argv.at(-2);\nconst args = JSON.parse(argv.at(-1) ?? '{}');\nprocess.stdout.write(JSON.stringify({ success: true, data: { fnName, args, argv } }));\n`,
+    );
+    chmodSync(fakeGodotPath, 0o755);
+
+    const result = runCli(
+      ['exec', 'get_project_info', '--project-path', tempRoot, '--format', 'json'],
+      { ...process.env, GODOT_FLOW_GODOT_PATH: fakeGodotPath },
+    );
+
+    assert.equal(result.status, 0, result.stderr);
+    const payload = JSON.parse(result.stdout) as {
+      success: boolean;
+      data: { fnName: string; args: Record<string, unknown>; argv: string[] };
+    };
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.fnName, 'get_project_info');
+    assert.deepEqual(payload.data.args, {});
+    assert.ok(payload.data.argv.includes('--headless'));
+    assert.ok(payload.data.argv.includes('--script'));
+    assert.ok(payload.data.argv.includes('src/scripts/godot_operations.gd'));
+  } finally {
+    rmSync(tempRoot, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary
- add compiled CLI smoke coverage for real entrypoints and one safe headless routing path
- run the compiled smoke suite in CI without requiring a real Godot binary
- clarify README wording so smoke coverage is not overstated as full end-to-end coverage

## Testing
- npm run build
- npm run typecheck
- npm run test:compiled
- npm test

Closes #17