### PR TITLE
fix: add preflight diagnostics for first-run UX

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,8 +104,18 @@ The AI discovers functions on-demand via `listfunc`/`findfunc`/`viewfunc`, then 
 ### Quick Start (recommended)
 
 ```bash
-npx godot-flow listfunc
+# Safe, read-only diagnostics first
+npx gopeak-cli doctor --format text
+
+# Works without a local Godot project/editor/runtime
+npx gopeak-cli listfunc
+
+# Add project-aware commands after configuring a project path
+export GODOT_FLOW_PROJECT_PATH=/path/to/project
+export GODOT_FLOW_GODOT_PATH=/path/to/Godot_v4.x
 ```
+
+`doctor` is the recommended first-run command. It reports missing project path, missing Godot binary, and runtime/editor/debug connectivity with suggested next steps instead of generic connection failures.
 
 ### Global Install
 
@@ -221,6 +231,20 @@ Output: Execution result (engine-specific)
 ```
 
 All 4 tools return both human-readable `content` (text) and machine-readable `structuredContent` (JSON) for maximum interoperability.
+
+## Capability Boundaries
+
+Use these prerequisite boundaries to avoid first-run confusion:
+
+| Capability | Example commands | Requires project path? | Requires Godot binary? | Requires live editor/runtime connectivity? |
+|---|---|---:|---:|---:|
+| Metadata-only discovery | `listfunc`, `findfunc`, `viewfunc`, `config`, `doctor` | No | No | No |
+| Headless project actions | `exec get_project_info`, most scene/resource operations | Yes | Yes | No |
+| Runtime bridge actions | runtime-engine functions | Usually yes | No | Yes - running game/runtime bridge |
+| Script/LSP actions | `exec lsp_diagnostics` | Yes | No | Yes - Godot editor open on LSP port |
+| Debug/DAP actions | DAP functions, `daemon start` | Yes | No | Yes - Godot debug adapter / daemon |
+
+If you are unsure which prerequisite is missing, run `gopeak-cli doctor --format text` first.
 
 ---
 
@@ -905,15 +929,17 @@ node -e "const m=require('./dist/registry/index');console.log(m.registry.count()
 
 ## Troubleshooting
 
-| Problem | Solution |
-|---------|----------|
-| **Godot not found** | Set `GODOT_FLOW_GODOT_PATH` to your Godot executable |
-| **No MCP tools visible** | Restart your MCP client after configuration |
-| **Project path invalid** | Ensure path contains `project.godot` |
-| **Runtime tools not working** | Start the game with `run_project` first, ensure runtime addon is enabled |
-| **LSP connection refused** | Open project in Godot editor (starts LSP automatically on port 6005) |
-| **DAP not connecting** | Ensure no other debugger is connected on port 6006 |
-| **Timeout errors** | Increase `GODOT_FLOW_TIMEOUT` for large projects |
+Start with: `gopeak-cli doctor --format text`
+
+| Problem | Actionable guidance |
+|---------|---------------------|
+| **Missing project path** | Run inside a Godot project, pass `--project-path /path/to/project`, or set `GODOT_FLOW_PROJECT_PATH`. The path must contain `project.godot`. |
+| **Godot not found** | Set `GODOT_FLOW_GODOT_PATH` to your Godot 4 executable and rerun `doctor`. |
+| **No MCP tools visible** | Restart your MCP client after configuration. |
+| **Runtime connection refused** | Start the game/project with the runtime addon enabled, then retry. `doctor` will show whether port `7777` is reachable. |
+| **LSP/editor connection refused** | Open the project in the Godot editor and wait for it to finish loading. `doctor` checks whether LSP port `6005` is reachable. |
+| **DAP/debug not connecting** | Start a Godot debug session or `gopeak-cli daemon start`, and ensure no other debugger is holding port `6006`. |
+| **Timeout errors** | Increase `GODOT_FLOW_TIMEOUT` for large projects or slow startup. |
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -20,7 +20,9 @@
     "prepare": "npm run build",
     "postinstall": "node -e \"try{require('child_process').execFileSync(process.execPath,['dist/cli.js','setup','--silent'],{stdio:'ignore'})}catch{}\"",
     "prepack": "npm run build",
-    "test": "node dist/daemon/request-loop.test.js"
+    "test": "npm run build && npm run test:compiled",
+    "test:compiled": "node --test dist/daemon/request-loop.test.js dist/cli.smoke.test.js dist/preflight.test.js",
+    "test:smoke": "npm run build && node --test dist/cli.smoke.test.js"
   },
   "keywords": [
     "godot",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -6,6 +6,7 @@ import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { spawnSync } from 'node:child_process';
 import { Command } from 'commander';
+import { createConnection } from 'node:net';
 import { registry } from './registry/index.js';
 import { executeHeadless } from './engine/headless.js';
 import { executeRuntime } from './engine/runtime.js';
@@ -59,6 +60,12 @@ interface DoctorReport {
     failed: number;
   };
   checks: DoctorCheck[];
+}
+
+interface ConnectivityProbeResult {
+  ok: boolean;
+  errorCode?: string;
+  output?: string;
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -117,6 +124,21 @@ function serializeCell(value: unknown): string {
   return JSON.stringify(value);
 }
 
+function isDoctorReport(value: unknown): value is DoctorReport {
+  return isRecord(value)
+    && isRecord(value.summary)
+    && Array.isArray(value.checks);
+}
+
+function printDoctorReport(report: DoctorReport): void {
+  process.stdout.write(`Doctor summary: ${report.summary.passed} passed, ${report.summary.warned} warned, ${report.summary.failed} failed\n`);
+
+  for (const check of report.checks) {
+    const icon = check.status === 'pass' ? '✓' : check.status === 'warn' ? '!' : '✗';
+    process.stdout.write(`${icon} ${check.name}: ${check.message}\n`);
+  }
+}
+
 function printTable(rows: Array<Record<string, unknown>>): void {
   if (rows.length === 0) {
     process.stdout.write('No results\n');
@@ -158,6 +180,11 @@ function outputSuccess(command: Command, payload: unknown): void {
 
   if (Array.isArray(payload) && payload.every((item) => isRecord(item))) {
     printTable(payload as Array<Record<string, unknown>>);
+    return;
+  }
+
+  if (isDoctorReport(payload)) {
+    printDoctorReport(payload);
     return;
   }
 
@@ -239,11 +266,19 @@ async function pathExists(path: string): Promise<boolean> {
   }
 }
 
-function checkCommandAvailability(command: string): { ok: boolean; output: string } {
+function checkCommandAvailability(command: string): { ok: boolean; output: string; errorCode?: string } {
   const result = spawnSync(command, ['--version'], {
     encoding: 'utf8',
     shell: false,
   });
+
+  if (result.error) {
+    return {
+      ok: false,
+      output: result.error.message,
+      errorCode: (result.error as NodeJS.ErrnoException).code,
+    };
+  }
 
   if (result.status === 0) {
     return {
@@ -256,6 +291,43 @@ function checkCommandAvailability(command: string): { ok: boolean; output: strin
     ok: false,
     output: (result.stderr || result.stdout || '').trim(),
   };
+}
+
+async function probePort(host: string, port: number, timeoutMs: number): Promise<ConnectivityProbeResult> {
+  return new Promise((resolve) => {
+    const socket = createConnection({ host, port });
+    let settled = false;
+
+    const finish = (result: ConnectivityProbeResult): void => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      clearTimeout(timer);
+      socket.destroy();
+      resolve(result);
+    };
+
+    const timer = setTimeout(() => {
+      finish({ ok: false, errorCode: 'ETIMEDOUT', output: `Timed out after ${timeoutMs}ms` });
+    }, timeoutMs);
+
+    socket.once('connect', () => finish({ ok: true }));
+    socket.once('error', (error: NodeJS.ErrnoException) => {
+      finish({ ok: false, errorCode: error.code, output: error.message });
+    });
+  });
+}
+
+function buildConnectivityMessage(name: 'runtime' | 'lsp' | 'dap', port: number): string {
+  switch (name) {
+    case 'runtime':
+      return `Runtime bridge is not reachable on port ${port}. Start the game/project with the runtime addon enabled, then retry.`;
+    case 'lsp':
+      return `Godot editor/LSP is not reachable on port ${port}. Open the project in the Godot editor before using script diagnostics or completion.`;
+    case 'dap':
+      return `Godot debug adapter is not reachable on port ${port}. Start a debug session in Godot or use gopeak-cli daemon start before debugger commands.`;
+  }
 }
 
 async function createDoctorReport(command: Command): Promise<DoctorReport> {
@@ -281,8 +353,13 @@ async function createDoctorReport(command: Command): Promise<DoctorReport> {
     status: godotCheck.ok ? 'pass' : 'warn',
     message: godotCheck.ok
       ? `Godot executable available: ${config.godotPath}`
-      : `Godot executable not found or not runnable: ${config.godotPath}`,
-    details: { configuredPath: config.godotPath, output: godotCheck.output },
+      : `Godot executable not found: ${config.godotPath}. Set ${CONFIG_ENV_KEYS.godotPath} to your Godot 4 executable.`,
+    details: {
+      configuredPath: config.godotPath,
+      output: godotCheck.output,
+      errorCode: godotCheck.errorCode,
+      suggestedCommands: [`export ${CONFIG_ENV_KEYS.godotPath}=/path/to/Godot_v4.x`],
+    },
   });
 
   if (config.projectPath) {
@@ -293,17 +370,57 @@ async function createDoctorReport(command: Command): Promise<DoctorReport> {
       status: projectFileExists ? 'pass' : 'warn',
       message: projectFileExists
         ? `Godot project detected: ${config.projectPath}`
-        : `Project path is missing or does not contain project.godot: ${config.projectPath}`,
-      details: { projectPath: config.projectPath },
+        : `Configured project path is not a Godot project: ${config.projectPath}. Expected project.godot at the project root.`,
+      details: {
+        projectPath: config.projectPath,
+        expectedFile: resolve(config.projectPath, 'project.godot'),
+        suggestedCommands: ['gopeak-cli doctor --project-path /path/to/project --format text'],
+      },
     });
   } else {
     checks.push({
       name: 'projectPath',
       status: 'warn',
-      message: `No project path configured. Set ${CONFIG_ENV_KEYS.projectPath} or pass --project-path.`,
-      details: { envKey: CONFIG_ENV_KEYS.projectPath },
+      message: `No project path configured. Run inside a Godot project, pass --project-path, or set ${CONFIG_ENV_KEYS.projectPath}.`,
+      details: {
+        envKey: CONFIG_ENV_KEYS.projectPath,
+        suggestedCommands: [
+          `export ${CONFIG_ENV_KEYS.projectPath}=/path/to/project`,
+          'gopeak-cli doctor --project-path /path/to/project --format text',
+        ],
+      },
     });
   }
+
+  const runtimeProbe = await probePort('127.0.0.1', config.runtimePort, Math.min(config.timeoutMs, 750));
+  checks.push({
+    name: 'runtimeConnectivity',
+    status: runtimeProbe.ok ? 'pass' : 'warn',
+    message: runtimeProbe.ok
+      ? `Runtime bridge reachable on port ${config.runtimePort}`
+      : buildConnectivityMessage('runtime', config.runtimePort),
+    details: { host: '127.0.0.1', port: config.runtimePort, errorCode: runtimeProbe.errorCode, output: runtimeProbe.output },
+  });
+
+  const lspProbe = await probePort('127.0.0.1', config.lspPort, Math.min(config.timeoutMs, 750));
+  checks.push({
+    name: 'lspConnectivity',
+    status: lspProbe.ok ? 'pass' : 'warn',
+    message: lspProbe.ok
+      ? `Godot LSP reachable on port ${config.lspPort}`
+      : buildConnectivityMessage('lsp', config.lspPort),
+    details: { host: '127.0.0.1', port: config.lspPort, errorCode: lspProbe.errorCode, output: lspProbe.output },
+  });
+
+  const dapProbe = await probePort('127.0.0.1', config.dapPort, Math.min(config.timeoutMs, 750));
+  checks.push({
+    name: 'dapConnectivity',
+    status: dapProbe.ok ? 'pass' : 'warn',
+    message: dapProbe.ok
+      ? `Godot DAP reachable on port ${config.dapPort}`
+      : buildConnectivityMessage('dap', config.dapPort),
+    details: { host: '127.0.0.1', port: config.dapPort, errorCode: dapProbe.errorCode, output: dapProbe.output },
+  });
 
   const codexSkillTarget = resolve(process.cwd(), '.codex/skills/gopeak-cli/SKILL.md');
   const claudeSkillTarget = resolve(process.cwd(), '.claude/skills/gopeak-cli/SKILL.md');

--- a/src/engine/dap.ts
+++ b/src/engine/dap.ts
@@ -171,10 +171,11 @@ class GodotDAPClient {
         clearTimeout(connectTimer);
         this.socket = null;
         reject(
-          new GodotFlowError('ENGINE_CONNECTION_FAILED', 'Failed to connect to Godot DAP server', {
+          new GodotFlowError('ENGINE_CONNECTION_FAILED', `Failed to connect to the Godot debug adapter at ${this.host}:${this.port}. Start a debug session in Godot or gopeak-cli daemon start, and ensure no other debugger is holding the port.`, {
             host: this.host,
             port: this.port,
             message: error.message,
+            suggestedCommands: ['gopeak-cli doctor --format text', 'gopeak-cli daemon start'],
           }),
         );
       });
@@ -575,6 +576,13 @@ export async function executeDAP(
   config: DAPConfig,
 ): Promise<ExecutionResult> {
   const startedAt = Date.now();
+  if (!config.projectPath) {
+    throw new GodotFlowError('INVALID_ARGS', 'DAP execution requires a Godot project path. Pass --project-path or set GODOT_FLOW_PROJECT_PATH.', {
+      fnName,
+      envKey: 'GODOT_FLOW_PROJECT_PATH',
+      suggestedCommands: ['gopeak-cli doctor --format text'],
+    });
+  }
   const client = new GodotDAPClient(config);
   const safeArgs: JsonRecord = isRecord(args) ? args : {};
 
@@ -667,9 +675,10 @@ export async function executeDAP(
       || message.includes('connect')
       || message.includes('DAP connection')
     ) {
-      throw new GodotFlowError('ENGINE_CONNECTION_FAILED', `DAP connection failed: ${message}`, {
+      throw new GodotFlowError('ENGINE_CONNECTION_FAILED', `DAP connection failed: ${message}. Start a Godot debug session or daemon and retry.`, {
         fnName,
         args: safeArgs,
+        suggestedCommands: ['gopeak-cli doctor --format text', 'gopeak-cli daemon start'],
       });
     }
 

--- a/src/engine/headless.ts
+++ b/src/engine/headless.ts
@@ -59,8 +59,13 @@ export async function executeHeadless(
   config: HeadlessConfig,
 ): Promise<ExecutionResult> {
   if (!config.projectPath) {
-    throw new GodotFlowError('INVALID_ARGS', 'Headless execution requires projectPath', {
+    throw new GodotFlowError('INVALID_ARGS', 'Headless execution requires a Godot project path. Run from a Godot project folder, pass --project-path, or set GODOT_FLOW_PROJECT_PATH.', {
       fnName,
+      envKey: 'GODOT_FLOW_PROJECT_PATH',
+      suggestedCommands: [
+        'gopeak-cli doctor --format text',
+        'gopeak-cli exec <function> --project-path /path/to/project',
+      ],
     });
   }
 
@@ -122,8 +127,10 @@ export async function executeHeadless(
       finish(() => {
         if (error.code === 'ENOENT') {
           reject(
-            new GodotFlowError('GODOT_NOT_FOUND', `Godot executable not found at path: ${config.godotPath}`, {
+            new GodotFlowError('GODOT_NOT_FOUND', `Godot executable not found at path: ${config.godotPath}. Set GODOT_FLOW_GODOT_PATH to your Godot 4 executable and rerun gopeak-cli doctor.`, {
               godotPath: config.godotPath,
+              envKey: 'GODOT_FLOW_GODOT_PATH',
+              suggestedCommands: ['gopeak-cli doctor --format text'],
             }),
           );
           return;

--- a/src/engine/lsp.ts
+++ b/src/engine/lsp.ts
@@ -145,10 +145,11 @@ class GodotLSPClient {
         if (!settled && !this.connected) {
           settled = true;
           rejectConnect(
-            new GodotFlowError('ENGINE_CONNECTION_FAILED', 'Failed to connect to Godot LSP server', {
+            new GodotFlowError('ENGINE_CONNECTION_FAILED', `Failed to connect to the Godot editor LSP at ${this.host}:${this.port}. Open the project in the Godot editor, wait for it to finish loading, then retry.`, {
               host: this.host,
               port: this.port,
               message: error.message,
+              suggestedCommands: ['gopeak-cli doctor --format text'],
             }),
           );
         }
@@ -590,6 +591,13 @@ export async function executeLSP(
     const parsedArgs: JsonRecord = isRecord(args) ? args : {};
     const { filePath, content } = await loadDocumentContent(parsedArgs);
     const projectPath = typeof config.projectPath === 'string' ? config.projectPath : undefined;
+    if (!projectPath) {
+      throw new GodotFlowError('INVALID_ARGS', 'LSP execution requires a Godot project path. Pass --project-path or set GODOT_FLOW_PROJECT_PATH.', {
+        fnName,
+        envKey: 'GODOT_FLOW_PROJECT_PATH',
+        suggestedCommands: ['gopeak-cli doctor --format text'],
+      });
+    }
 
     let data: unknown;
 
@@ -666,7 +674,7 @@ export async function executeLSP(
       || message.includes('connect')
       || message.includes('Not connected')
     ) {
-      throw new GodotFlowError('ENGINE_CONNECTION_FAILED', `LSP connection failed: ${message}`, detailsBase);
+      throw new GodotFlowError('ENGINE_CONNECTION_FAILED', `LSP connection failed: ${message}. Open the project in the Godot editor and rerun gopeak-cli doctor if needed.`, { ...detailsBase, suggestedCommands: ['gopeak-cli doctor --format text'] });
     }
 
     throw new GodotFlowError('EXECUTION_FAILED', `LSP execution failed: ${message}`, detailsBase);

--- a/src/engine/runtime.ts
+++ b/src/engine/runtime.ts
@@ -227,7 +227,7 @@ export async function executeRuntime(
 
     socket.on('error', (error: NodeJS.ErrnoException) => {
       const message = error.code === 'ECONNREFUSED'
-        ? `Failed to connect to Godot runtime at ${config.host}:${config.port}. Ensure the game is running with the runtime addon enabled.`
+        ? `Failed to connect to the Godot runtime at ${config.host}:${config.port}. Start the game/project with the runtime addon enabled, then retry.`
         : `Runtime TCP connection failed: ${error.message}`;
 
       finishReject(
@@ -237,6 +237,7 @@ export async function executeRuntime(
           port: config.port,
           code: error.code ?? 'UNKNOWN',
           cause: error.message,
+          suggestedCommands: ['gopeak-cli doctor --format text'],
         }),
       );
     });

--- a/src/preflight.test.ts
+++ b/src/preflight.test.ts
@@ -1,0 +1,120 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { executeRuntime } from './engine/runtime.js';
+import { executeLSP } from './engine/lsp.js';
+import { executeDAP } from './engine/dap.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const distCliPath = resolve(__dirname, './cli.js');
+
+function runCli(args: string[], env: NodeJS.ProcessEnv = process.env) {
+  return spawnSync(process.execPath, [distCliPath, ...args], {
+    env,
+    encoding: 'utf8',
+  });
+}
+
+test('doctor reports actionable warnings for missing project path, Godot, and connectivity', () => {
+  const tempRoot = mkdtempSync(join(tmpdir(), 'gopeak-preflight-'));
+
+  try {
+    const result = runCli(['doctor', '--format', 'json'], {
+      ...process.env,
+      GODOT_FLOW_PROJECT_PATH: '',
+      GODOT_FLOW_GODOT_PATH: join(tempRoot, 'missing-godot'),
+      GODOT_FLOW_RUNTIME_PORT: '65531',
+      GODOT_FLOW_LSP_PORT: '65532',
+      GODOT_FLOW_DAP_PORT: '65533',
+    });
+
+    assert.equal(result.status, 0, result.stderr);
+    const payload = JSON.parse(result.stdout) as {
+      summary: { warned: number };
+      checks: Array<{ name: string; status: string; message: string }>;
+    };
+
+    assert.ok(payload.summary.warned >= 4);
+    const byName = new Map(payload.checks.map((check) => [check.name, check]));
+    assert.match(byName.get('projectPath')?.message ?? '', /--project-path|GODOT_FLOW_PROJECT_PATH/);
+    assert.match(byName.get('godot')?.message ?? '', /GODOT_FLOW_GODOT_PATH/);
+    assert.match(byName.get('runtimeConnectivity')?.message ?? '', /runtime addon enabled/i);
+    assert.match(byName.get('lspConnectivity')?.message ?? '', /Godot editor/i);
+    assert.match(byName.get('dapConnectivity')?.message ?? '', /daemon start|debug session/i);
+  } finally {
+    rmSync(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test('headless execution failure explains how to provide project path', () => {
+  const result = runCli(['exec', 'get_project_info', '--format', 'json'], {
+    ...process.env,
+    GODOT_FLOW_PROJECT_PATH: '',
+  });
+
+  assert.equal(result.status, 1);
+  const payload = JSON.parse(result.stderr) as { error: { code: string; message: string } };
+  assert.equal(payload.error.code, 'INVALID_ARGS');
+  assert.match(payload.error.message, /--project-path/);
+  assert.match(payload.error.message, /GODOT_FLOW_PROJECT_PATH/);
+});
+
+test('doctor text output is readable and checklist-style', () => {
+  const result = runCli(['doctor', '--format', 'text'], process.env);
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /Doctor summary:/);
+  assert.match(result.stdout, /projectPath:/);
+  assert.match(result.stdout, /runtimeConnectivity:/);
+});
+
+test('runtime connection failure suggests starting the runtime addon', async () => {
+  await assert.rejects(
+    () => executeRuntime('runtime_ping', {}, {
+      host: '127.0.0.1',
+      port: 65531,
+      projectPath: undefined,
+      timeoutMs: 250,
+    }),
+    (error: unknown) => {
+      assert.ok(error instanceof Error);
+      assert.match(error.message, /runtime addon enabled/i);
+      return true;
+    },
+  );
+});
+
+test('lsp and dap missing project path errors are actionable', async () => {
+  await assert.rejects(
+    () => executeLSP('lsp_diagnostics', { filePath: '/tmp/player.gd', content: 'extends Node\n' }, {
+      host: '127.0.0.1',
+      port: 65532,
+      projectPath: undefined,
+      timeoutMs: 250,
+    }),
+    (error: unknown) => {
+      assert.ok(error instanceof Error);
+      assert.match(error.message, /GODOT_FLOW_PROJECT_PATH/);
+      return true;
+    },
+  );
+
+  await assert.rejects(
+    () => executeDAP('debug_list_breakpoints', {}, {
+      host: '127.0.0.1',
+      port: 65533,
+      projectPath: undefined,
+      timeoutMs: 250,
+    }),
+    (error: unknown) => {
+      assert.ok(error instanceof Error);
+      assert.match(error.message, /GODOT_FLOW_PROJECT_PATH/);
+      return true;
+    },
+  );
+});


### PR DESCRIPTION
## Summary
- add doctor/preflight-style checks for missing project path, missing Godot binary, and runtime/LSP/DAP connectivity
- make failure messages actionable for headless/runtime/LSP/DAP paths instead of generic connection errors
- document capability boundaries and troubleshooting steps, and add focused preflight tests

## Testing
- npm run typecheck
- npm run build
- npm test